### PR TITLE
Handle nullable TextureView surface

### DIFF
--- a/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
+++ b/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
@@ -81,9 +81,9 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
     }
 
     private fun createSession(size: Size) {
-        val surface = Surface(textureView.surfaceTexture.apply {
-            setDefaultBufferSize(size.width, size.height)
-        })
+        val surfaceTexture = textureView.surfaceTexture ?: return
+        surfaceTexture.setDefaultBufferSize(size.width, size.height)
+        val surface = Surface(surfaceTexture)
 
         previewRequestBuilder = cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW)
         previewRequestBuilder.addTarget(surface)


### PR DESCRIPTION
## Summary
- prevent null crash when creating camera preview surface

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9502b1d4832ba0462de679a9a011