### PR TITLE
Handle camera permission result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Gradle
 build/
 app/build/
+.gradle/
 
 # Android Studio
 .local.properties

--- a/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
+++ b/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
@@ -53,6 +53,21 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) ==
                 PackageManager.PERMISSION_GRANTED
 
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == 0 && grantResults.isNotEmpty() &&
+            grantResults[0] == PackageManager.PERMISSION_GRANTED
+        ) {
+            textureView.post { openCamera() }
+        } else {
+            finish()
+        }
+    }
+
     private fun openCamera() {
         val manager = getSystemService(CameraManager::class.java)
         val cameraId = manager.cameraIdList.first()


### PR DESCRIPTION
## Summary
- handle camera permission callback to open the camera or exit gracefully
- ignore local `.gradle` directories

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae98e9febc832b9538d973beabe997