### PR TITLE
Enable Japanese OCR using ML Kit

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.12.0'
 
-    implementation 'com.google.mlkit:text-recognition:16.0.0'
+    // ML Kit Japanese text recognition
+    implementation 'com.google.mlkit:text-recognition-japanese:16.0.0'
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="true" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
+++ b/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.graphics.ImageFormat
 import android.os.Bundle
 import android.util.Size
+import android.util.SparseIntArray
 import android.view.Surface
 import android.view.TextureView
 import android.widget.TextView
@@ -17,7 +18,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
-import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.google.mlkit.vision.text.japanese.JapaneseTextRecognizerOptions
 
 class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListener {
 
@@ -30,7 +31,16 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
     private lateinit var previewRequestBuilder: CaptureRequest.Builder
     private lateinit var backgroundHandler: Handler
 
-    private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    private val orientations = SparseIntArray().apply {
+        append(Surface.ROTATION_0, 0)
+        append(Surface.ROTATION_90, 90)
+        append(Surface.ROTATION_180, 180)
+        append(Surface.ROTATION_270, 270)
+    }
+
+    // Use ML Kit's Japanese text recognizer
+    private val recognizer =
+        TextRecognition.getClient(JapaneseTextRecognizerOptions.Builder().build())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -117,7 +127,8 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
 
     override fun onImageAvailable(reader: ImageReader) {
         val image = reader.acquireLatestImage() ?: return
-        val input = InputImage.fromMediaImage(image, 0)
+        val rotation = orientations[windowManager.defaultDisplay.rotation]
+        val input = InputImage.fromMediaImage(image, rotation)
         recognizer.process(input)
             .addOnSuccessListener { textView.text = it.text }
             .addOnFailureListener { }


### PR DESCRIPTION
## Summary
- replace generic text recognition dependency with ML Kit's Japanese text recognizer
- configure CameraOcrActivity to use JapaneseTextRecognizerOptions for on-device OCR and handle device rotation
- declare camera hardware requirement in manifest

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9b7ad9e4832babdd9bc7245a04d9