### PR TITLE
Fix AppCompat theme crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
     <application
         android:allowBackup="true"
         android:label="@string/app_name"
-        android:supportsRtl="true">
+        android:supportsRtl="true"
+        android:theme="@style/Theme.OcrML">
         <activity
             android:name=".CameraOcrActivity"
             android:exported="true">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,5 @@
+<resources>
+    <style name="Theme.OcrML" parent="Theme.AppCompat.Light.NoActionBar">
+        <!-- Customize your theme here. -->
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- add AppCompat-based app theme
- set application to use new theme

## Testing
- ⚠️ `gradle build` *(missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9e108920832bb07457561321a03d