### PR TITLE
Limit OCR to card overlay region

### DIFF
--- a/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
+++ b/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
@@ -3,11 +3,13 @@ package com.example.ocrml
 import android.Manifest
 import android.content.pm.PackageManager
 import android.graphics.ImageFormat
+import android.graphics.Rect
 import android.os.Bundle
 import android.util.Size
 import android.util.SparseIntArray
 import android.view.Surface
 import android.view.TextureView
+import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
@@ -24,6 +26,7 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
 
     private lateinit var textureView: TextureView
     private lateinit var textView: TextView
+    private lateinit var overlay: View
 
     private lateinit var cameraDevice: CameraDevice
     private lateinit var captureSession: CameraCaptureSession
@@ -47,6 +50,7 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         setContentView(R.layout.activity_camera_ocr)
         textureView = findViewById(R.id.preview)
         textView = findViewById(R.id.result)
+        overlay = findViewById(R.id.ocr_area)
 
         val handlerThread = HandlerThread("CameraBackground")
         handlerThread.start()
@@ -129,6 +133,17 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         val image = reader.acquireLatestImage() ?: return
         val rotation = orientations[windowManager.defaultDisplay.rotation]
         val input = InputImage.fromMediaImage(image, rotation)
+        val viewWidth = textureView.width
+        val viewHeight = textureView.height
+        val scaleX = image.width.toFloat() / viewWidth
+        val scaleY = image.height.toFloat() / viewHeight
+        val rect = Rect(
+            (overlay.left * scaleX).toInt(),
+            (overlay.top * scaleY).toInt(),
+            (overlay.right * scaleX).toInt(),
+            (overlay.bottom * scaleY).toInt()
+        )
+        input.setCropRect(rect)
         recognizer.process(input)
             .addOnSuccessListener { textView.text = it.text }
             .addOnFailureListener { }

--- a/app/src/main/res/drawable/card_overlay.xml
+++ b/app/src/main/res/drawable/card_overlay.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@android:color/transparent" />
+    <stroke android:width="2dp" android:color="#FF00FF00" />
+</shape>

--- a/app/src/main/res/layout/activity_camera_ocr.xml
+++ b/app/src/main/res/layout/activity_camera_ocr.xml
@@ -8,6 +8,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <View
+        android:id="@+id/ocr_area"
+        android:layout_width="250dp"
+        android:layout_height="150dp"
+        android:layout_gravity="center"
+        android:background="@drawable/card_overlay" />
+
     <TextView
         android:id="@+id/result"
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- draw centered card overlay to indicate scan area
- crop camera frames to overlay before OCR to improve speed

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb469520c832b94f158572eac7119