### PR TITLE
Fix crop rect handling in CameraOcrActivity

### DIFF
--- a/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
+++ b/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
@@ -132,7 +132,6 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
     override fun onImageAvailable(reader: ImageReader) {
         val image = reader.acquireLatestImage() ?: return
         val rotation = orientations[windowManager.defaultDisplay.rotation]
-        val input = InputImage.fromMediaImage(image, rotation)
         val viewWidth = textureView.width
         val viewHeight = textureView.height
         val scaleX = image.width.toFloat() / viewWidth
@@ -143,7 +142,7 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
             (overlay.right * scaleX).toInt(),
             (overlay.bottom * scaleY).toInt()
         )
-        input.setCropRect(rect)
+        val input = InputImage.fromMediaImage(image, rotation, rect)
         recognizer.process(input)
             .addOnSuccessListener { textView.text = it.text }
             .addOnFailureListener { }


### PR DESCRIPTION
## Summary
- pass crop rectangle when creating InputImage instead of calling non-existent setCropRect

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb61ffd44832bb62075f4a89d7674