### PR TITLE
Add overlay mask and fix crop recognition

### DIFF
--- a/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
+++ b/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
@@ -9,7 +9,6 @@ import android.util.Size
 import android.util.SparseIntArray
 import android.view.Surface
 import android.view.TextureView
-import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
@@ -26,7 +25,7 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
 
     private lateinit var textureView: TextureView
     private lateinit var textView: TextView
-    private lateinit var overlay: View
+    private lateinit var overlay: OverlayView
 
     private lateinit var cameraDevice: CameraDevice
     private lateinit var captureSession: CameraCaptureSession
@@ -50,7 +49,7 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         setContentView(R.layout.activity_camera_ocr)
         textureView = findViewById(R.id.preview)
         textView = findViewById(R.id.result)
-        overlay = findViewById(R.id.ocr_area)
+        overlay = findViewById<OverlayView>(R.id.ocr_area)
 
         val handlerThread = HandlerThread("CameraBackground")
         handlerThread.start()
@@ -136,13 +135,15 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         val viewHeight = textureView.height
         val scaleX = image.width.toFloat() / viewWidth
         val scaleY = image.height.toFloat() / viewHeight
+        val box = overlay.getBoxRect()
         val rect = Rect(
-            (overlay.left * scaleX).toInt(),
-            (overlay.top * scaleY).toInt(),
-            (overlay.right * scaleX).toInt(),
-            (overlay.bottom * scaleY).toInt()
+            (box.left * scaleX).toInt(),
+            (box.top * scaleY).toInt(),
+            (box.right * scaleX).toInt(),
+            (box.bottom * scaleY).toInt()
         )
-        val input = InputImage.fromMediaImage(image, rotation, rect)
+        val input = InputImage.fromMediaImage(image, rotation)
+        input.cropRect = rect
         recognizer.process(input)
             .addOnSuccessListener { textView.text = it.text }
             .addOnFailureListener { }

--- a/app/src/main/java/com/example/ocrml/OverlayView.kt
+++ b/app/src/main/java/com/example/ocrml/OverlayView.kt
@@ -1,0 +1,51 @@
+package com.example.ocrml
+
+import android.content.Context
+import android.graphics.*
+import android.util.AttributeSet
+import android.view.View
+
+class OverlayView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val borderPaint = Paint().apply {
+        style = Paint.Style.STROKE
+        color = Color.GREEN
+        strokeWidth = 4f
+    }
+
+    private val maskPaint = Paint().apply {
+        style = Paint.Style.FILL
+        color = 0x80000000.toInt()
+    }
+
+    private val boxRect = Rect()
+    private val path = Path()
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        val boxWidth = 250f * resources.displayMetrics.density
+        val boxHeight = 150f * resources.displayMetrics.density
+        val left = ((w - boxWidth) / 2f).toInt()
+        val top = ((h - boxHeight) / 2f).toInt()
+        val right = (left + boxWidth).toInt()
+        val bottom = (top + boxHeight).toInt()
+        boxRect.set(left, top, right, bottom)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        path.reset()
+        path.addRect(0f, 0f, width.toFloat(), height.toFloat(), Path.Direction.CW)
+        path.addRect(RectF(boxRect), Path.Direction.CCW)
+        path.fillType = Path.FillType.EVEN_ODD
+        canvas.drawPath(path, maskPaint)
+        canvas.drawRect(boxRect, borderPaint)
+    }
+
+    fun getBoxRect(): Rect = boxRect
+}
+

--- a/app/src/main/res/layout/activity_camera_ocr.xml
+++ b/app/src/main/res/layout/activity_camera_ocr.xml
@@ -8,12 +8,10 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <View
+    <com.example.ocrml.OverlayView
         android:id="@+id/ocr_area"
-        android:layout_width="250dp"
-        android:layout_height="150dp"
-        android:layout_gravity="center"
-        android:background="@drawable/card_overlay" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
     <TextView
         android:id="@+id/result"


### PR DESCRIPTION
## Summary
- draw a semi-transparent mask with a centered border rectangle for the OCR area
- limit text recognition to the selected box by applying a crop rect to InputImage

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec41d74fc832b9c217541a6e9d3f9