### PR TITLE
feat: expand and raise OCR box with rounded corners

### DIFF
--- a/app/src/main/java/com/example/ocrml/OverlayView.kt
+++ b/app/src/main/java/com/example/ocrml/OverlayView.kt
@@ -24,16 +24,19 @@ class OverlayView @JvmOverloads constructor(
 
     private val boxRect = Rect()
     private val path = Path()
+    private val cornerRadius = 16f * resources.displayMetrics.density
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        val boxWidth = 250f * resources.displayMetrics.density
-        val boxHeight = 150f * resources.displayMetrics.density
-        val offsetY = 80f * resources.displayMetrics.density
-        val left = ((w - boxWidth) / 2f).toInt()
-        val top = (((h - boxHeight) / 2f) - offsetY).toInt().coerceAtLeast(0)
-        val right = (left + boxWidth).toInt()
-        val bottom = (top + boxHeight).toInt()
+        val boxWidth = 300f * resources.displayMetrics.density
+        val boxHeight = 180f * resources.displayMetrics.density
+        val expansion = 30f * resources.displayMetrics.density
+        val offsetY = 120f * resources.displayMetrics.density
+        val left = ((w - boxWidth) / 2f - expansion / 2f).toInt()
+        val top = (((h - boxHeight) / 2f) - offsetY - expansion / 2f)
+            .toInt().coerceAtLeast(0)
+        val right = (left + boxWidth + expansion).toInt()
+        val bottom = (top + boxHeight + expansion).toInt()
         boxRect.set(left, top, right, bottom)
     }
 
@@ -41,10 +44,10 @@ class OverlayView @JvmOverloads constructor(
         super.onDraw(canvas)
         path.reset()
         path.addRect(0f, 0f, width.toFloat(), height.toFloat(), Path.Direction.CW)
-        path.addRect(RectF(boxRect), Path.Direction.CCW)
+        path.addRoundRect(RectF(boxRect), cornerRadius, cornerRadius, Path.Direction.CCW)
         path.fillType = Path.FillType.EVEN_ODD
         canvas.drawPath(path, maskPaint)
-        canvas.drawRect(boxRect, borderPaint)
+        canvas.drawRoundRect(RectF(boxRect), cornerRadius, cornerRadius, borderPaint)
     }
 
     fun getBoxRect(): Rect = boxRect


### PR DESCRIPTION
## Summary
- enlarge OCR overlay box dimensions and margin
- shift overlay upward while keeping rounded corners

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afec10e894832b81463f198f2239f1