### PR TITLE
Adjust camera preview size and orientation

### DIFF
--- a/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
+++ b/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
@@ -4,7 +4,9 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.ImageFormat
+import android.graphics.Matrix
 import android.graphics.Rect
+import android.graphics.RectF
 import android.os.Bundle
 import android.util.Size
 import android.view.Surface
@@ -14,6 +16,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import android.hardware.camera2.*
+import android.hardware.camera2.params.StreamConfigurationMap
 import android.media.Image
 import android.media.ImageReader
 import android.os.Handler
@@ -84,8 +87,12 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         val cameraId = manager.cameraIdList.first()
 
         val characteristics = manager.getCameraCharacteristics(cameraId)
-        val map = characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
-        val size = map!!.getOutputSizes(ImageFormat.YUV_420_888)[0]
+        val map = characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)!!
+
+        val viewWidth = textureView.width
+        val viewHeight = textureView.height
+        val size = chooseOptimalSize(map, viewWidth, viewHeight)
+        val sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION) ?: 0
 
         imageReader = ImageReader.newInstance(size.width, size.height, ImageFormat.YUV_420_888, 2)
         imageReader.setOnImageAvailableListener(this, backgroundHandler)
@@ -93,7 +100,7 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         manager.openCamera(cameraId, object : CameraDevice.StateCallback() {
             override fun onOpened(device: CameraDevice) {
                 cameraDevice = device
-                createSession(size)
+                createSession(size, sensorOrientation)
             }
 
             override fun onDisconnected(device: CameraDevice) {
@@ -106,9 +113,10 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         }, backgroundHandler)
     }
 
-    private fun createSession(size: Size) {
+    private fun createSession(size: Size, sensorOrientation: Int) {
         val surfaceTexture = textureView.surfaceTexture ?: return
         surfaceTexture.setDefaultBufferSize(size.width, size.height)
+        configureTransform(size, sensorOrientation)
         val surface = Surface(surfaceTexture)
 
         previewRequestBuilder = cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW)
@@ -124,6 +132,43 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
 
                 override fun onConfigureFailed(session: CameraCaptureSession) { }
             }, backgroundHandler)
+    }
+
+    private fun chooseOptimalSize(map: StreamConfigurationMap, viewWidth: Int, viewHeight: Int): Size {
+        val targetRatio = viewWidth.toFloat() / viewHeight
+        return map.getOutputSizes(ImageFormat.YUV_420_888).minByOrNull {
+            kotlin.math.abs(it.width.toFloat() / it.height - targetRatio)
+        } ?: map.getOutputSizes(ImageFormat.YUV_420_888)[0]
+    }
+
+    private fun configureTransform(previewSize: Size, sensorOrientation: Int) {
+        val rotation = windowManager.defaultDisplay.rotation
+        val rotationDegrees = when (rotation) {
+            Surface.ROTATION_0 -> 0
+            Surface.ROTATION_90 -> 90
+            Surface.ROTATION_180 -> 180
+            Surface.ROTATION_270 -> 270
+            else -> 0
+        }
+
+        val diff = (sensorOrientation - rotationDegrees + 360) % 360
+        val swapped = diff == 90 || diff == 270
+        if (!swapped) return
+
+        val matrix = Matrix()
+        val viewRect = RectF(0f, 0f, textureView.width.toFloat(), textureView.height.toFloat())
+        val bufferRect = RectF(0f, 0f, previewSize.height.toFloat(), previewSize.width.toFloat())
+        val centerX = viewRect.centerX()
+        val centerY = viewRect.centerY()
+        bufferRect.offset(centerX - bufferRect.centerX(), centerY - bufferRect.centerY())
+        matrix.setRectToRect(viewRect, bufferRect, Matrix.ScaleToFit.FILL)
+        val scale = kotlin.math.max(
+            textureView.height.toFloat() / previewSize.height,
+            textureView.width.toFloat() / previewSize.width
+        )
+        matrix.postScale(scale, scale, centerX, centerY)
+        matrix.postRotate(diff.toFloat(), centerX, centerY)
+        textureView.setTransform(matrix)
     }
 
     override fun onImageAvailable(reader: ImageReader) {


### PR DESCRIPTION
## Summary
- Choose output size matching TextureView aspect ratio
- Set SurfaceTexture buffer to chosen size
- Rotate and scale TextureView when sensor orientation differs from display

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00584495c832bbba329641b39d7cb