### PR TITLE
Use AutoFitTextureView to keep camera preview aspect ratio

### DIFF
--- a/app/src/main/java/com/example/ocrml/AutoFitTextureView.kt
+++ b/app/src/main/java/com/example/ocrml/AutoFitTextureView.kt
@@ -1,0 +1,48 @@
+package com.example.ocrml
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.TextureView
+
+/**
+ * A [TextureView] that can be adjusted to a specified aspect ratio.
+ * This is used to avoid stretching the camera preview when the
+ * preview size's aspect ratio differs from the view's dimensions.
+ */
+class AutoFitTextureView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0
+) : TextureView(context, attrs, defStyle) {
+
+    private var ratioWidth = 0
+    private var ratioHeight = 0
+
+    /**
+     * Sets the aspect ratio for this view. The size of the view will be
+     * measured based on the ratio calculated from the parameters. Note
+     * that the actual sizes of parameters don't matter, that is, calling
+     * setAspectRatio(2, 3) and setAspectRatio(4, 6) make the same result.
+     */
+    fun setAspectRatio(width: Int, height: Int) {
+        require(width > 0 && height > 0) { "Size cannot be negative" }
+        ratioWidth = width
+        ratioHeight = height
+        requestLayout()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val width = MeasureSpec.getSize(widthMeasureSpec)
+        val height = MeasureSpec.getSize(heightMeasureSpec)
+        if (ratioWidth == 0 || ratioHeight == 0) {
+            setMeasuredDimension(width, height)
+        } else {
+            if (width < height * ratioWidth / ratioHeight) {
+                setMeasuredDimension(width, width * ratioHeight / ratioWidth)
+            } else {
+                setMeasuredDimension(height * ratioWidth / ratioHeight, height)
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
+++ b/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
@@ -10,7 +10,7 @@ import android.graphics.RectF
 import android.os.Bundle
 import android.util.Size
 import android.view.Surface
-import android.view.TextureView
+import com.example.ocrml.AutoFitTextureView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
@@ -21,13 +21,14 @@ import android.media.Image
 import android.media.ImageReader
 import android.os.Handler
 import android.os.HandlerThread
+import android.content.res.Configuration
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.japanese.JapaneseTextRecognizerOptions
 
 class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListener {
 
-    private lateinit var textureView: TextureView
+    private lateinit var textureView: AutoFitTextureView
     private lateinit var textView: TextView
     private lateinit var overlay: OverlayView
 
@@ -93,6 +94,12 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         val viewHeight = textureView.height
         val size = chooseOptimalSize(map, viewWidth, viewHeight)
         val sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION) ?: 0
+
+        if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            textureView.setAspectRatio(size.width, size.height)
+        } else {
+            textureView.setAspectRatio(size.height, size.width)
+        }
 
         imageReader = ImageReader.newInstance(size.width, size.height, ImageFormat.YUV_420_888, 2)
         imageReader.setOnImageAvailableListener(this, backgroundHandler)

--- a/app/src/main/res/layout/activity_camera_ocr.xml
+++ b/app/src/main/res/layout/activity_camera_ocr.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextureView
+    <com.example.ocrml.AutoFitTextureView
         android:id="@+id/preview"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />


### PR DESCRIPTION
## Summary
- introduce AutoFitTextureView that maintains a given aspect ratio
- apply AutoFitTextureView in camera layout and activity
- set texture view aspect ratio to match chosen preview size

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b008bd3a58832b8e46be6eb640435e