### PR TITLE
Fix camera preview scaling to avoid stretched image

### DIFF
--- a/app/src/main/java/com/example/ocrml/AutoFitTextureView.kt
+++ b/app/src/main/java/com/example/ocrml/AutoFitTextureView.kt
@@ -5,44 +5,13 @@ import android.util.AttributeSet
 import android.view.TextureView
 
 /**
- * A [TextureView] that can be adjusted to a specified aspect ratio.
- * This is used to avoid stretching the camera preview when the
- * preview size's aspect ratio differs from the view's dimensions.
+ * A simple [TextureView] used for displaying the camera preview. The
+ * preview's aspect ratio and rotation are handled with a transformation
+ * matrix inside [CameraOcrActivity], so this view intentionally performs
+ * no additional measurement or scaling on its own.
  */
 class AutoFitTextureView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0
-) : TextureView(context, attrs, defStyle) {
-
-    private var ratioWidth = 0
-    private var ratioHeight = 0
-
-    /**
-     * Sets the aspect ratio for this view. The size of the view will be
-     * measured based on the ratio calculated from the parameters. Note
-     * that the actual sizes of parameters don't matter, that is, calling
-     * setAspectRatio(2, 3) and setAspectRatio(4, 6) make the same result.
-     */
-    fun setAspectRatio(width: Int, height: Int) {
-        require(width > 0 && height > 0) { "Size cannot be negative" }
-        ratioWidth = width
-        ratioHeight = height
-        requestLayout()
-    }
-
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val width = MeasureSpec.getSize(widthMeasureSpec)
-        val height = MeasureSpec.getSize(heightMeasureSpec)
-        if (ratioWidth == 0 || ratioHeight == 0) {
-            setMeasuredDimension(width, height)
-        } else {
-            if (width < height * ratioWidth / ratioHeight) {
-                setMeasuredDimension(width, width * ratioHeight / ratioWidth)
-            } else {
-                setMeasuredDimension(height * ratioWidth / ratioHeight, height)
-            }
-        }
-    }
-}
-
+) : TextureView(context, attrs, defStyle)

--- a/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
+++ b/app/src/main/java/com/example/ocrml/CameraOcrActivity.kt
@@ -21,7 +21,6 @@ import android.media.Image
 import android.media.ImageReader
 import android.os.Handler
 import android.os.HandlerThread
-import android.content.res.Configuration
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.japanese.JapaneseTextRecognizerOptions
@@ -95,12 +94,6 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
         val size = chooseOptimalSize(map, viewWidth, viewHeight)
         val sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION) ?: 0
 
-        if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            textureView.setAspectRatio(size.width, size.height)
-        } else {
-            textureView.setAspectRatio(size.height, size.width)
-        }
-
         imageReader = ImageReader.newInstance(size.width, size.height, ImageFormat.YUV_420_888, 2)
         imageReader.setOnImageAvailableListener(this, backgroundHandler)
 
@@ -149,6 +142,8 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
     }
 
     private fun configureTransform(previewSize: Size, sensorOrientation: Int) {
+        if (textureView.width == 0 || textureView.height == 0) return
+
         val rotation = windowManager.defaultDisplay.rotation
         val rotationDegrees = when (rotation) {
             Surface.ROTATION_0 -> 0
@@ -157,21 +152,22 @@ class CameraOcrActivity : AppCompatActivity(), ImageReader.OnImageAvailableListe
             Surface.ROTATION_270 -> 270
             else -> 0
         }
-
         val diff = (sensorOrientation - rotationDegrees + 360) % 360
-        val swapped = diff == 90 || diff == 270
-        if (!swapped) return
 
         val matrix = Matrix()
         val viewRect = RectF(0f, 0f, textureView.width.toFloat(), textureView.height.toFloat())
-        val bufferRect = RectF(0f, 0f, previewSize.height.toFloat(), previewSize.width.toFloat())
+        val bufferRect = if (diff == 90 || diff == 270) {
+            RectF(0f, 0f, previewSize.height.toFloat(), previewSize.width.toFloat())
+        } else {
+            RectF(0f, 0f, previewSize.width.toFloat(), previewSize.height.toFloat())
+        }
         val centerX = viewRect.centerX()
         val centerY = viewRect.centerY()
         bufferRect.offset(centerX - bufferRect.centerX(), centerY - bufferRect.centerY())
-        matrix.setRectToRect(viewRect, bufferRect, Matrix.ScaleToFit.FILL)
+        matrix.setRectToRect(bufferRect, viewRect, Matrix.ScaleToFit.FILL)
         val scale = kotlin.math.max(
-            textureView.height.toFloat() / previewSize.height,
-            textureView.width.toFloat() / previewSize.width
+            viewRect.height() / bufferRect.height(),
+            viewRect.width() / bufferRect.width()
         )
         matrix.postScale(scale, scale, centerX, centerY)
         matrix.postRotate(diff.toFloat(), centerX, centerY)


### PR DESCRIPTION
## Summary
- simplify AutoFitTextureView so preview relies on transform matrix
- adjust CameraOcrActivity to scale and rotate preview correctly without stretching

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00ed98d3c832b89589086d137023f