### PR TITLE
Add stable “氏名” recognition with rescan option

### DIFF
--- a/app/src/main/res/layout/activity_camera_ocr.xml
+++ b/app/src/main/res/layout/activity_camera_ocr.xml
@@ -13,12 +13,27 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <TextView
-        android:id="@+id/result"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
+        android:orientation="vertical"
         android:background="#80000000"
-        android:textColor="#ffffff"
-        android:padding="16dp" />
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/result"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="#ffffff" />
+
+        <Button
+            android:id="@+id/rescan_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="重新扫描"
+            android:layout_gravity="center_horizontal"
+            android:visibility="gone" />
+
+    </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
## Summary
- Track OCR lines and capture the line containing "氏名"
- Freeze result after it appears unchanged three times and show a rescan button
- Add UI button to restart scanning

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b138e4d27c832b9ffa5744cd305942